### PR TITLE
Update react-native dependency to 0.66.1 in frontend/tablet/package.json and frontend/tablet/yarn.lock 

### DIFF
--- a/frontend/tablet/package.json
+++ b/frontend/tablet/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "17.0.2",
-    "react-native": "0.66.0"
+    "react-native": "^0.66.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/frontend/tablet/yarn.lock
+++ b/frontend/tablet/yarn.lock
@@ -5566,10 +5566,10 @@ react-native-codegen@^0.0.7:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
-react-native@0.66.0:
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.66.0.tgz#99bdd83a9a612a71b94242767989d666d445b007"
-  integrity sha512-m26TKwzsfHVdZ1hDG+7mZ4M4ftxFFZrhtiT0OXuwfBzmNtB3xhsJtYszPeizw33c9YNp8rvehKT3c4ldDCW6kA==
+react-native@^0.66.1:
+  version "0.66.1"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.66.1.tgz#96defaf60579406321340ebe1dcea76a3c942806"
+  integrity sha512-BBvytmqlOLL+bRcO0jBiYfg16lYRsYDOC8/5E+bpnhb3EGtU+YCQAYfszw6JL7Hfy0ftnQNP5yj8pt+vqMHXIA==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^6.0.0"


### PR DESCRIPTION
- Update react-native dependency to 0.66.1 in frontend/tablet/package.json and frontend/tablet/yarn.lock