### PR TITLE
[Tablet] Hiding system bars in room detail

### DIFF
--- a/frontend/tablet/package.json
+++ b/frontend/tablet/package.json
@@ -25,6 +25,7 @@
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.9.0",
     "react-native-svg": "^12.1.1",
+    "react-native-system-navigation-bar": "^1.0.2",
     "shared": "../shared"
   },
   "devDependencies": {

--- a/frontend/tablet/src/screens/RoomDetailScreen/index.tsx
+++ b/frontend/tablet/src/screens/RoomDetailScreen/index.tsx
@@ -1,6 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack'
 import React from 'react'
 import { StyleSheet } from 'react-native'
+import SystemNavigationBar from 'react-native-system-navigation-bar'
 
 import { NavigatorStackParamList } from '..'
 import { Typography, Screen, Grid } from '../../components'
@@ -17,6 +18,8 @@ const RoomDetailScreen: React.FC<RoomDetailProps> = ({
   route,
 }: RoomDetailProps) => {
   const { room } = route.params
+
+  SystemNavigationBar.stickyImmersive()
 
   return (
     <Screen>

--- a/frontend/tablet/yarn.lock
+++ b/frontend/tablet/yarn.lock
@@ -5996,6 +5996,11 @@ react-native-svg@^12.1.1:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
+react-native-system-navigation-bar@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-system-navigation-bar/-/react-native-system-navigation-bar-1.0.2.tgz#c930eeb8f56429e8843e4c4f3ac23bbd57745b55"
+  integrity sha512-qaqJlQLksBF1Q+OJB0gMeAql8iXHGpeG/VNcGTRFt7W4M0iY35au5GHSntbpxm/7/OagfVf4WU3ppGEK7MvbZg==
+
 react-native@^0.66.3:
   version "0.66.3"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.66.3.tgz#25c7c4c7d81867326b3eb7a36f0fe6a61fa4104e"


### PR DESCRIPTION
- Hiding navigation and system bar for `RoomDetailScreen`,
- Opening this bars with specific gesture from upper and lower edge of screen for short time,
- Works only for Android, maybe similar solution is made for iOS, if not, we can find another solution for this problem.